### PR TITLE
fixed route from signup to singin and viseversa

### DIFF
--- a/frontend/components/login-form.tsx
+++ b/frontend/components/login-form.tsx
@@ -110,7 +110,7 @@ export function LoginForm({
               <Field>
                 <Button type="submit">Login</Button>
                 <FieldDescription className="text-center">
-                  Don&apos;t have an account? <a href="#">Sign up</a>
+                  Don&apos;t have an account? <a href="/signup">Sign up</a>
                 </FieldDescription>
               </Field>
             </FieldGroup>

--- a/frontend/components/signup-form.tsx
+++ b/frontend/components/signup-form.tsx
@@ -89,7 +89,7 @@ export function SignupForm({
               <Field>
                 <Button type="submit">Create Account</Button>
                 <FieldDescription className="text-center">
-                  Already have an account? <a href="/signin">Sign in</a>
+                  Already have an account? <a href="/login">Sign in</a>
                 </FieldDescription>
               </Field>
             </FieldGroup>


### PR DESCRIPTION
This pull request updates the navigation links in the login and signup forms to ensure users are directed to the correct authentication pages.

Authentication flow improvements:

* Updated the "Sign up" link in `frontend/components/login-form.tsx` to point to `/signup` instead of a placeholder, making the registration page accessible from the login form.
* Changed the "Sign in" link in `frontend/components/signup-form.tsx` to point to `/login` instead of `/signin`, ensuring consistency in authentication routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Changelog

## [2025-12-03]

### Fixed
- **Authentication Navigation Routes**: Corrected navigation links in authentication forms to ensure proper routing between login and signup pages
  - Updated "Sign up" link in login form to point to `/signup` (previously was a placeholder "#")
  - Changed "Sign in" link in signup form to point to `/login` (previously was `/signin`)

### Files Modified
- `frontend/components/login-form.tsx`
- `frontend/components/signup-form.tsx`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->