### PR TITLE
fixed problem of arxivtool and pdfparser tool,and cleaned description workflow file,

### DIFF
--- a/langgraph_bot/nodes/tnode/description_tool_node.py
+++ b/langgraph_bot/nodes/tnode/description_tool_node.py
@@ -29,7 +29,9 @@ def pdf_parsing_node(state:State):
 
     papers_to_read = papers[:4] #using top 4 pdfs only
 
-    docs = pdfreader_tool.invoke(papers_to_read)
+    docs = pdfreader_tool.invoke({
+    "pdf_list": papers_to_read
+})
 
     return {
         "documents": docs

--- a/langgraph_bot/workflow/description_workflow.py
+++ b/langgraph_bot/workflow/description_workflow.py
@@ -27,35 +27,5 @@ desc.add_edge("description_agent",END)
 g = desc.compile()
 
 
-
-inputs = {
-    "messages": [],
-}
-
-final_state =g.invoke(inputs)
-
-
-for msg in final_state:
-    print("------------------------------------------")
-    print(msg)
-    print("------------------------------------------")
-    if msg == "arxiv_urls":
-        print(final_state[msg][0]["abstract"])
-        print()
-    if msg == "tavily_search_result":
-      i = 0
-      for result in final_state[msg]['results']:
-        print(f"result {i}")
-        i+=1
-        print(result['content'])
-        # print(result['url'])
-        print()
-    if msg == "description":
-      print("==================================================================================================================================")
-      print(final_state[msg])
-      print("==================================================================================================================================")
-      print()
-
-
-
 g.get_graph().draw_mermaid_png(output_file_path='./agent_flow_diagrams/description.png')
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Changelog - 2026-01-05

## Fixed

- **PDF Parser Tool Integration**: Fixed `pdf_parsing_node` to pass parameters to `pdfreader_tool` using the correct dictionary format with "pdf_list" key instead of directly passing the raw list. This resolves compatibility issues with the pdf parser tool architecture.

- **ArXiv Tool Integration**: Corrected the invocation pattern for arxiv tool to align with the new agent architecture, ensuring proper data flow in the description workflow.

## Changed

- **Description Workflow Cleanup**: Removed runtime execution code from `description_workflow.py` that was invoking the graph with test data and printing intermediate results. The workflow file now only contains the graph definition and diagram visualization, eliminating test code from the production workflow file.

**Files Modified:**
- `langgraph_bot/nodes/tnode/description_tool_node.py`
- `langgraph_bot/workflow/description_workflow.py`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->