### PR TITLE
fix: update conditional for run-langgraph-bot job in workflow

### DIFF
--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   run-langgraph-bot:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'recent-ai/Ai-Dictionary' }}
     runs-on: ubuntu-latest
     environment: Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Added
 
 - **GitHub Actions workflow** (.github/workflows/run_workflow.yml)
-  - Workflow name: "Run Test LangGraph Bot Worflow"
+  - Workflow name: "Run Test LangGraph Bot Workflow"
   - Triggers: manual (workflow_dispatch) and daily cron at 14:00 UTC
   - Job: `run-langgraph-bot` on `ubuntu-latest` (environment: backend), 30-minute timeout
   - Steps: checkout, install `uv` (with cache), install Python 3.12.5, sync dependencies for `./backend` and `./langgraph_bot` (`uv sync --frozen`), run LangGraph bot (`uv run python -m langgraph_bot.main`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,45 @@ All notable changes to the AI-Dictionary project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+### March 26, 2026
 
+#### Added
+
+- **GitHub Actions workflow** (.github/workflows/run_workflow.yml)
+  - Workflow name: "Run Test LangGraph Bot Worflow"
+  - Triggers: manual (workflow_dispatch) and daily cron at 14:00 UTC
+  - Job: `run-langgraph-bot` on `ubuntu-latest` (environment: backend), 30-minute timeout
+  - Steps: checkout, install `uv` (with cache), install Python 3.12.5, sync dependencies for `./backend` and `./langgraph_bot` (`uv sync --frozen`), run LangGraph bot (`uv run python -m langgraph_bot.main`)
+  - Runtime env/secrets provided: PYTHONPATH, SUPABASE_URL, SUPABASE_KEY, GROQ_API_KEY, TAVILY_API_KEY
+
+- **Graph PNG writer** (langgraph_bot/workflow/description_workflow.py)
+  - Added `write_description_graph_png() -> pathlib.Path` which ensures `langgraph_bot/agent_flow_diagrams/` exists, writes `description.png` via `g.get_graph().draw_mermaid_png(...)`, and returns the output path
+  - Makes PNG generation opt-in to avoid filesystem side-effects at import time
+
+#### Changed
+
+- **Data fetching** (backend/db/repository/fetch_raw_data.py)
+  - `fetch_last_days_posts()` temporarily uses a fixed start date `2026-01-13` for the `created_at >=` filter (replaces previous dynamic `get_previous_day()` logic)
+  - Added runtime prints for debugging:
+    - "Fetched some posts from the database."
+    - "Number of posts fetched: <n>"
+
+- **LangGraph bot entrypoint** (langgraph_bot/main.py)
+  - Commented out startup PNG generation and its print (graph generation disabled at startup); `run_entire_flow()` and subsequent printing of results remain unchanged
+
+- **Workflow graph** (langgraph_bot/workflow/description_workflow.py)
+  - Temporarily disabled the `arxiv_node` in the graph (node registration and edges commented out) and rewired control flow to start at `parser_tool`, skipping `arxiv_node` due to API issues
 
 ### January 14, 2026
 
 #### Fixed
+
 - Database Column Population: Inserted source name field in API response to populate the `source_name` column in the database.
   - `services/newsapi_scrapper/news_api_fetcher.py`: Added `source_name` to each article dictionary (populated from `x["source"]["name"]`) returned by `get_newsapi_data`.
   - `db/repository/insert_newsapi_data.py`: Uses the enhanced article objects when upserting into `raw_api_data` (imported `get_newsapi_data`).
 
 #### Changed
+
 - Article structure: `get_newsapi_data()` now returns articles with fields: `source_name`, `website`, `description` (full scraped content), `title`, and `created_at`.
 - Data fetching: Full article content is populated via `get_full_article_content()` before articles are added to the cleaned list.
 - Minor docstring cleanup: whitespace-only edit in `get_previous_day()`.
@@ -27,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Blog Page Assets - Static svgs for static blog pages.  
 
 #### Other
+
 - Cleanup commit: removed a test script to tidy the module.
 
 ### January 13, 2026


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Changelog

## [2026-03-30]

### Fixed
- **GitHub Actions Workflow** (.github/workflows/run_workflow.yml)
  - Updated job-level conditional for run-langgraph-bot:
    - if: ${{ github.event_name != 'schedule' || github.repository == 'recent-ai/Ai-Dictionary' }}
  - Behavior:
    - Prevents the job from running on scheduled (cron) events in forks while allowing scheduled runs in the primary repository (recent-ai/Ai-Dictionary).
    - Allows all non-schedule events (e.g., manual workflow_dispatch) to run in any repository.
  - No other workflow steps, environment variables, or runtime logic were changed.

### Added / Documented
- **CHANGELOG.md**
  - Added a March 26, 2026 section documenting:
    - Addition of a GitHub Actions workflow to run langgraph_bot via manual dispatch and a daily cron.
    - Addition of write_description_graph_png() -> pathlib.Path to langgraph_bot/workflow/description_workflow.py (ensures target directory exists and writes description.png using g.get_graph().draw_mermaid_png()).
    - Changes to backend fetch behavior (fetch_last_days_posts() temporarily uses a fixed start date 2026-01-13) and added debug printouts for fetch activity and post counts.
    - LangGraph bot entrypoint: startup PNG generation commented out (PNG creation made opt-in), run_entire_flow() execution unchanged.
    - Temporary disabling of arxiv_node in the workflow graph and rewiring execution to start at parser_tool due to API issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->