### PR TITLE
Add Raw data insert in DB Workflow

### DIFF
--- a/.github/workflows/run_backend_main_workflow.yml
+++ b/.github/workflows/run_backend_main_workflow.yml
@@ -1,0 +1,47 @@
+name: Run Backend Main Workflow
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: "35 4 * * *" # Works at 4:35 AM every day UTC
+
+jobs:
+  run-backend-main:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'recent-ai/Ai-Dictionary' }}
+    runs-on: ubuntu-latest
+    environment: Workflow
+
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Setup Python 3.12.5
+        run: uv python install 3.12.5
+
+      - name: Install Backend Dependencies
+        working-directory: ./backend
+        run: uv sync --frozen
+
+      - name: Run Backend Main Workflow
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+          NEWSAPI_ORG_KEY: ${{ secrets.NEWSAPI_ORG_KEY }}
+          product_hunt_access_token: ${{ secrets.PRODUCT_HUNT_ACCESS_TOKEN || secrets.product_hunt_access_token }}
+        run: |
+          cd backend
+          source .venv/bin/activate
+          cd ..
+          uv run python -m backend.services.main

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -1,14 +1,15 @@
 name: Run Test LangGraph Bot Workflow
 
 on:
-  workflow_dispatch:
-
-  schedule:
-    - cron: "35 4 * * *" #Works at 4:35 AM every day UTC 
+  workflow_run:
+    workflows:
+      - Run Backend Main Workflow
+    types:
+      - completed
 
 jobs:
   run-langgraph-bot:
-    if: ${{ github.event_name != 'schedule' || github.repository == 'recent-ai/Ai-Dictionary' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: Workflow
 

--- a/backend/db/repository/insert_raw_api_data.py
+++ b/backend/db/repository/insert_raw_api_data.py
@@ -19,6 +19,8 @@ def insert_raw_api_data(data: list[dict] | None = None):
         from backend.services.main import fetch_all_data
 
         data = fetch_all_data()
+    elif not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise TypeError("data must be a list[dict]")
 
     if not data:
         print("No data fetched to insert.")

--- a/backend/db/repository/insert_raw_api_data.py
+++ b/backend/db/repository/insert_raw_api_data.py
@@ -1,5 +1,4 @@
 from backend.db.client import supabase
-from backend.services.main import fetch_all_data
 
 
 def normalize(item):
@@ -17,6 +16,8 @@ def normalize(item):
 
 def insert_raw_api_data(data: list[dict] | None = None):
     if data is None:
+        from backend.services.main import fetch_all_data
+
         data = fetch_all_data()
 
     if not data:

--- a/backend/db/repository/insert_raw_api_data.py
+++ b/backend/db/repository/insert_raw_api_data.py
@@ -15,8 +15,9 @@ def normalize(item):
     return {k: v for k, v in clean.items() if v is not None}
 
 
-def insert_raw_api_data():
-    data = fetch_all_data()
+def insert_raw_api_data(data: list[dict] | None = None):
+    if data is None:
+        data = fetch_all_data()
 
     if not data:
         print("No data fetched to insert.")

--- a/backend/services/main.py
+++ b/backend/services/main.py
@@ -92,6 +92,8 @@ def run_fetch_and_store():
 
     data = fetch_all_data()
     result = insert_raw_api_data(data)
+    if result.get("inserted", 0) == 0:
+        raise RuntimeError("Fetch succeeded but no records were inserted into raw_api_data")
     print(f"Inserted {result['inserted']} items into raw_api_data")
     return result
 

--- a/backend/services/main.py
+++ b/backend/services/main.py
@@ -13,6 +13,7 @@ from backend.services.marktechpost_scraper.test_mtp_scraper import (
 from backend.services.newsapi_scrapper.news_api_fetcher import get_newsapi_data
 
 from backend.services.product_hunt_wrapper.ph_wrapper import ProductHuntWrapper
+from backend.db.repository.insert_raw_api_data import insert_raw_api_data
 
 # MTP Scraper
 firecrawl_api_key = os.getenv("FIRECRAWL_API_KEY")
@@ -87,5 +88,12 @@ def fetch_all_data():
     return all_data
 
 
+def run_fetch_and_store():
+    data = fetch_all_data()
+    result = insert_raw_api_data(data)
+    print(f"Inserted {result['inserted']} items into raw_api_data")
+    return result
+
+
 if __name__ == "__main__":
-    fetch_all_data()
+    run_fetch_and_store()

--- a/backend/services/main.py
+++ b/backend/services/main.py
@@ -13,7 +13,6 @@ from backend.services.marktechpost_scraper.test_mtp_scraper import (
 from backend.services.newsapi_scrapper.news_api_fetcher import get_newsapi_data
 
 from backend.services.product_hunt_wrapper.ph_wrapper import ProductHuntWrapper
-from backend.db.repository.insert_raw_api_data import insert_raw_api_data
 
 # MTP Scraper
 firecrawl_api_key = os.getenv("FIRECRAWL_API_KEY")
@@ -89,6 +88,8 @@ def fetch_all_data():
 
 
 def run_fetch_and_store():
+    from backend.db.repository.insert_raw_api_data import insert_raw_api_data
+
     data = fetch_all_data()
     result = insert_raw_api_data(data)
     print(f"Inserted {result['inserted']} items into raw_api_data")

--- a/backend/services/marktechpost_scraper/mtp_scraper.py
+++ b/backend/services/marktechpost_scraper/mtp_scraper.py
@@ -62,8 +62,6 @@ def fetch_blog_urls(url_mtp: str, user_agent: str) -> set:
                     f"https://www.marktechpost.com/{curr_year}/{curr_month}/{curr_day}/[^/]+/$"
                 )
             )
-                )
-            )
             for blog in blogs:
                 blog_links.add(blog["href"])
         return blog_links
@@ -87,6 +85,7 @@ def fetch_tech_news_only(blog_links: set, user_agent: str) -> set:
         return tutorial_links_set
     except requests.exceptions.RequestException as e:
         print(f"Error filtering tutorials {e}")
+        return set()
 
 
 # Extract/ Scrape content using FireCrawl API

--- a/backend/services/marktechpost_scraper/mtp_scraper.py
+++ b/backend/services/marktechpost_scraper/mtp_scraper.py
@@ -41,44 +41,42 @@ def fetching_user_agents() -> list:
         raise
 
 
-def fetch_blog_urls(url_mtp: str, user_agents: list) -> set:
+def fetch_blog_urls(url_mtp: str, user_agent: str) -> set:
     blog_links = set()
     try:
-        for _headers in user_agents:
-            header = {"User-Agent": f"{_headers}"}
-            response = requests.get(url=url_mtp, headers=header, timeout=10)
-            # check for connection_errors if any
-            response.raise_for_status()
+        header = {"User-Agent": f"{user_agent}"}
+        response = requests.get(url=url_mtp, headers=header, timeout=10)
+        # check for connection_errors if any
+        response.raise_for_status()
 
-            soup = BeautifulSoup(response.content, "lxml")
-            curr_year = date.today().strftime("%Y")
-            curr_month = date.today().strftime("%m")
-            # Fetch blogs from last 4 days, excluding todays day
-            # because we have 1 day delay for extra leverage for safety
-            for day in range(2, 0, -1):
-                curr_day = (date.today() - timedelta(day)).strftime("%d")
-                blogs = soup.find_all(
-                    href=re.compile(
-                        f"https://www.marktechpost.com/{curr_year}/{curr_month}/{curr_day}/[^/]+/$"
-                    )
+        soup = BeautifulSoup(response.content, "lxml")
+        curr_year = date.today().strftime("%Y")
+        curr_month = date.today().strftime("%m")
+        # Fetch blogs from last 4 days, excluding todays day
+        # because we have 1 day delay for extra leverage for safety
+        for day in range(2, 0, -1):
+            curr_day = (date.today() - timedelta(day)).strftime("%d")
+            blogs = soup.find_all(
+                href=re.compile(
+                    f"https://www.marktechpost.com/{curr_year}/{curr_month}/{curr_day}/[^/]+/$"
                 )
-                for blog in blogs:
-                    blog_links.add(blog["href"])
+            )
+            for blog in blogs:
+                blog_links.add(blog["href"])
             if response.status_code == 200:
                 break
         return blog_links
     except requests.exceptions.RequestException as e:
         print(f"Error fetching the data from url {e}")
-        raise
 
 
-def fetch_tech_news_only(blog_links: set, user_agents: list) -> set:
+def fetch_tech_news_only(blog_links: set, user_agent: str) -> set:
     tutorial_links_set = set()
     try:
         for url in blog_links:
-            if not user_agents:
+            if not user_agent:
                 raise Exception("User Agent Empty")
-            header = {"User-Agent": f"{user_agents[0]}"}
+            header = {"User-Agent": f"{user_agent}"}
             blog_res = requests.get(url, headers=header)
             blog_soup = BeautifulSoup(blog_res.text, "lxml")
             block = blog_soup.find("div", class_="td-post-header")

--- a/backend/services/marktechpost_scraper/mtp_scraper.py
+++ b/backend/services/marktechpost_scraper/mtp_scraper.py
@@ -50,15 +50,18 @@ def fetch_blog_urls(url_mtp: str, user_agent: str) -> set:
         response.raise_for_status()
 
         soup = BeautifulSoup(response.content, "lxml")
-        curr_year = date.today().strftime("%Y")
-        curr_month = date.today().strftime("%m")
         # Fetch blogs from last 4 days, excluding todays day
         # because we have 1 day delay for extra leverage for safety
-        for day in range(3, 0, -1):
-            curr_day = (date.today() - timedelta(day)).strftime("%d")
+        for day_offset in range(3, 0, -1):
+            target_date = date.today() - timedelta(days=day_offset)
+            curr_year = target_date.strftime("%Y")
+            curr_month = target_date.strftime("%m")
+            curr_day = target_date.strftime("%d")
             blogs = soup.find_all(
                 href=re.compile(
                     f"https://www.marktechpost.com/{curr_year}/{curr_month}/{curr_day}/[^/]+/$"
+                )
+            )
                 )
             )
             for blog in blogs:

--- a/backend/services/marktechpost_scraper/mtp_scraper.py
+++ b/backend/services/marktechpost_scraper/mtp_scraper.py
@@ -54,7 +54,7 @@ def fetch_blog_urls(url_mtp: str, user_agent: str) -> set:
         curr_month = date.today().strftime("%m")
         # Fetch blogs from last 4 days, excluding todays day
         # because we have 1 day delay for extra leverage for safety
-        for day in range(2, 0, -1):
+        for day in range(3, 0, -1):
             curr_day = (date.today() - timedelta(day)).strftime("%d")
             blogs = soup.find_all(
                 href=re.compile(
@@ -63,8 +63,6 @@ def fetch_blog_urls(url_mtp: str, user_agent: str) -> set:
             )
             for blog in blogs:
                 blog_links.add(blog["href"])
-            if response.status_code == 200:
-                break
         return blog_links
     except requests.exceptions.RequestException as e:
         print(f"Error fetching the data from url {e}")

--- a/backend/services/marktechpost_scraper/test_mtp_scraper.py
+++ b/backend/services/marktechpost_scraper/test_mtp_scraper.py
@@ -62,7 +62,7 @@ def test_fetch_blog_urls():
     """Test fetching blog URLs and filtering tutorials."""
     print("Fetching user agents...")
     user_agents = ua.random
-    print(f"Found {len(user_agents)} user agents\n")
+    # print(f"Found {len(user_agents)} user agents\n")
 
     print("Fetching blog URLs from MarkTechPost...")
     blog_links = fetch_blog_urls(url_mtp, user_agents)

--- a/backend/services/marktechpost_scraper/test_mtp_scraper.py
+++ b/backend/services/marktechpost_scraper/test_mtp_scraper.py
@@ -88,13 +88,13 @@ def test_full_scrape_pipeline():
 
     # Fetch blog URLs
     print("Fetching user agents...")
-    user_agents = ua.random
+    user_agent = ua.random
 
     print("Fetching blog URLs...")
-    blog_links = fetch_blog_urls(url_mtp, user_agents)
+    blog_links = fetch_blog_urls(url_mtp, user_agent)
 
     print("Filtering tutorial links...")
-    tutorial_urls = fetch_tech_news_only(blog_links, user_agents)
+    tutorial_urls = fetch_tech_news_only(blog_links, user_agent)
     blog_links = blog_links - tutorial_urls
     blog_links_list = list(blog_links)
     total_urls = len(blog_links)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Changelog

**Date:** April 12, 2026

## GitHub Actions
- Added workflow: .github/workflows/run_backend_main_workflow.yml
  - Triggers: manual (workflow_dispatch) and daily UTC cron (04:35)
  - Runs on ubuntu-latest, 30-minute timeout
  - Steps: checkout, install uv, install Python 3.12.5, sync backend deps (uv sync --frozen), run `python -m backend.services.main` via `uv run`
  - Exposes runtime env/secrets: SUPABASE_URL/KEY, FIRECRAWL_API_KEY, NEWSAPI_ORG_KEY, product_hunt_access_token (supports alternate secret casing)
- Updated workflow: .github/workflows/run_workflow.yml
  - Trigger changed to workflow_run for completion of "Run Backend Main Workflow"
  - Job gating simplified to run only when the triggering workflow concluded with 'success'

## Backend — DB & Services
- backend/db/repository/insert_raw_api_data.py
  - Signature changed to insert_raw_api_data(data: list[dict] | None = None)
  - Supports optional injected data (uses provided list) or lazy-fetches via fetch_all_data when data is None
  - Validates input type (raises TypeError for invalid shapes); preserves normalization, upsert on "website", skip logic, and returned shape {"inserted": <count>}
- backend/services/main.py
  - Added run_fetch_and_store(): fetches via fetch_all_data(), calls insert_raw_api_data(data), raises RuntimeError if zero records inserted, prints and returns insert result
  - __main__ now runs run_fetch_and_store() so the module performs fetch + persist by default

## MarkTechPost Scraper
- backend/services/marktechpost_scraper/mtp_scraper.py
  - fetch_blog_urls(url_mtp, user_agent: str) now accepts a single user_agent string (not a list)
    - Uses one User-Agent header per request, expands date window to 3 days (range(3, 0, -1)), removes prior multi-request early-exit, and returns blog links or prints on request errors
  - fetch_tech_news_only(blog_links, user_agent: str) now accepts a single user_agent string
    - Validates presence of user_agent; on request errors returns an empty set

## Tests
- backend/services/marktechpost_scraper/test_mtp_scraper.py
  - Updated to pass single user_agent values (renamed variables accordingly)
  - Suppressed debug print of generated user agents; test control flow and multithreaded scraping unchanged
<!-- end of auto-generated comment: release notes by coderabbit.ai -->