### PR TITLE
Add new workflow for LangGraph Bot testing

### DIFF
--- a/.github/workflows/test_new_workflow.yml
+++ b/.github/workflows/test_new_workflow.yml
@@ -1,0 +1,58 @@
+name: Run Test LangGraph Bot Workflow
+
+on:
+  workflow_run:
+    workflows:
+      - Run Backend Main Workflow
+    types:
+      - completed
+
+jobs:
+  run-langgraph-bot:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: Workflow
+
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+        with:
+          ref: test-new-workflow
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Setup Python 3.12.5
+        run: uv python install 3.12.5
+
+      - name: Install Backend Dependencies
+        working-directory: ./backend
+        run: uv sync --frozen
+
+      - name: Install LangGraph Bot Dependencies
+        working-directory: ./langgraph_bot
+        run: uv sync --frozen
+
+      - name: Run LangGraph Bot Main Test Workflow
+        # working-directory: ./langgraph_bot
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGSMITH_ENDPOINT: ${{ secrets.LANGSMITH_ENDPOINT }}
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGCHAIN_TRACING_V2 }}
+          LANGCHAIN_PROJECT: ${{ secrets.LANGCHAIN_PROJECT }}
+        run: |
+          cd langgraph_bot
+          source .venv/bin/activate
+          cd ..
+          uv run python -m langgraph_bot.main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Changelog

## [2026-05-04]

### Added
- **New GitHub Actions Workflow**: Added `Run Test LangGraph Bot Workflow` (`.github/workflows/test_new_workflow.yml`) that automatically triggers upon successful completion of the "Run Backend Main Workflow"
  - Configures automated testing for the LangGraph Bot using `workflow_run` event
  - Sets up Python 3.12.5 environment with `uv` package manager
  - Installs dependencies for both backend and langgraph_bot modules using frozen lockfiles
  - Runs the LangGraph bot main module with required environment variables sourced from GitHub secrets (Supabase, Groq, Tavily, LangSmith, and tracing/project settings)
  - Executes on ubuntu-latest with a 30-minute timeout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->