### PR TITLE
fix: Manual Worflow actions run

### DIFF
--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -1,6 +1,12 @@
 name: Run Test LangGraph Bot Workflow
 
 on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch or tag to run against
+        required: true
+        type: string
   workflow_run:
     workflows:
       - Run Backend Main Workflow
@@ -9,15 +15,23 @@ on:
 
 jobs:
   run-langgraph-bot:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: Workflow
-
     timeout-minutes: 30
 
     steps:
-      - name: Checkout the Repository
+      - name: Checkout workflow_dispatch ref
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Checkout workflow_run ref
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -37,10 +51,8 @@ jobs:
         run: uv sync --frozen
 
       - name: Run LangGraph Bot Main Test Workflow
-        # working-directory: ./langgraph_bot
         env:
           PYTHONPATH: ${{ github.workspace }}
-
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog - May 4, 2026

### Fixed
- **Manual Workflow Actions Run** (PR #91)
  - Added `workflow_dispatch` support to enable manual triggering of the workflow
  - Added `ref` input parameter to allow checking out specific branches or tags when manually dispatching the workflow
  - Updated `run-langgraph-bot` job to execute on both manual dispatch and successful completion of the dependent "Run Backend Main Workflow"
  - Split checkout logic into two conditional steps:
    - Step for manual dispatch: checks out the provided `inputs.ref`
    - Step for workflow_run events: checks out `github.event.workflow_run.head_branch`
  - Set explicit `PYTHONPATH` environment variable to `${{ github.workspace }}` in LangGraph bot test step execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->