### PR TITLE
fix: Handle None values for slug in post data and reducer function

### DIFF
--- a/langgraph_bot/agentschema/stateschema.py
+++ b/langgraph_bot/agentschema/stateschema.py
@@ -15,10 +15,11 @@ def replace_reducer(current: str, new: str) -> str:
     we have do append operation . if both operation takes place at same time it might be posible to override the current value with none, 
     to overcome this issue, this reducer fucntion is here.
     """
-    if current is None :
+    if new is not None:
         return new
-    elif new is None:
+    if current is not None:
         return current
+    return ""
 
 class State(TypedDict):
     # If you want to keep history of strings, use operator.add

--- a/langgraph_bot/main.py
+++ b/langgraph_bot/main.py
@@ -35,7 +35,7 @@ def run_entire_flow():
                 "summary": result.get("summary"),
                 "description": result.get("description"),
                 "source": post.get("source_name"),
-                "slug":result.get("slug")
+                "slug":result.get("slug") or ""
             }
             time.sleep(12)
         except Exception as e:


### PR DESCRIPTION
The reducer function returns None in case both current and new are None 
Which violates the state schema because it is set as string and not `Optional`
Problems:- 
- Caused the graph to fail, processing further nodes which also failed 
- The graph would fail but it still used the tokes for the LLM call, I think
- Our code in `main` also is kinda incorrect for exception handling
- Pipeline runs successfully but content is inserted as None in DB, which is also an issue   

The fix helps in solving the above problem 

A Future follow up PR can include using some sort of regex to form slug from title if llm fails in filling the value 
it could be a follow up to this @coderabbitai Can you make this suggestion as a issue 

[Reference](https://github.com/recent-ai/Ai-Dictionary/actions/runs/25537410762/job/74955962863)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Changelog

**Date:** May 8, 2026

## Fixed

- **Handle None values for slug in reducer function** — Modified `replace_reducer()` in `langgraph_bot/agentschema/stateschema.py` to return an empty string `""` as fallback instead of potentially returning `None`. This ensures the reducer always returns a string type, preventing state schema violations.

- **Ensure slug defaults to empty string in post data** — Updated `run_entire_flow()` in `langgraph_bot/main.py` to provide a default empty string for `slug` when it is missing from the LLM result, preventing `None` values from being inserted into the database and avoiding downstream graph processing failures.

## Impact

These changes resolve graph processing failures caused by `None` slug values and prevent the pipeline from completing with invalid data in the database while still consuming LLM tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->