### PR TITLE
feat: Implement TitleBlock generation and update workflow to use new title node

### DIFF
--- a/langgraph_bot/agents/summaryagent.py
+++ b/langgraph_bot/agents/summaryagent.py
@@ -7,14 +7,13 @@ from langchain.agents import create_agent
 
 from langgraph_bot.agentschema.stateschema import State
 from langgraph_bot.models.generativemodel import groqmodel
-from langgraph_bot.tools.tools import title_tool
 from langgraph_bot.utils.prompts import SUMMARY_PROMPT
 
 s_agent = create_agent(  # s refers to summary
     model=groqmodel,
     state_schema=State,
     system_prompt=SUMMARY_PROMPT,
-    tools=[title_tool],
+    tools=[],
 )
 
 

--- a/langgraph_bot/agentschema/stateschema.py
+++ b/langgraph_bot/agentschema/stateschema.py
@@ -21,6 +21,15 @@ def replace_reducer(current: str, new: str) -> str:
         return current
     return ""
 
+
+def replace_dict_reducer(current: Optional[dict], new: Optional[dict]) -> dict:
+    if new is not None:
+        return new
+    if current is not None:
+        return current
+    return {}
+
+
 class State(TypedDict):
     # If you want to keep history of strings, use operator.add
     # If you just want the current value, use 'overwrite'
@@ -34,6 +43,7 @@ class State(TypedDict):
     # These also need reducers if multiple nodes update them at once
     topic: Annotated[Optional[str], replace_reducer]
     title: Annotated[Optional[str], replace_reducer]
+    title_block: Annotated[Optional[dict], replace_dict_reducer]
     summary: Annotated[Optional[str], replace_reducer]
     description: Annotated[Optional[str], replace_reducer]
     

--- a/langgraph_bot/insert_bot_data.py
+++ b/langgraph_bot/insert_bot_data.py
@@ -26,6 +26,7 @@ def insert_cleaned_data(posts: list):
             content_data = {
                 "postid": post_id,
                 "content": {
+                    "title": post.get("title_block"),
                     "summary": post.get("summary"),
                     "description": post.get("description"),
                     "slug": post.get("slug"),

--- a/langgraph_bot/main.py
+++ b/langgraph_bot/main.py
@@ -33,6 +33,7 @@ def run_entire_flow():
             # Return clean structured output with only relevant fields
             clean_post = {
                 "title": result.get("title") or post.get("title"),
+                "title_block": result.get("title_block"),
                 "summary": result.get("summary"),
                 "description": result.get("description"),
                 "source": post.get("source_name"),

--- a/langgraph_bot/nodes/tnode/title_node.py
+++ b/langgraph_bot/nodes/tnode/title_node.py
@@ -1,8 +1,27 @@
+from datetime import datetime, timezone
+from typing import Literal
+
 from langchain_core.messages import ToolMessage
+from langchain_core.output_parsers import PydanticOutputParser
+from pydantic import BaseModel
+
 from langgraph_bot.agentschema.stateschema import State
-from langgraph_bot.tools.tools import title_tool,slug_tool
+from langgraph_bot.models.generativemodel import groqmodel
+from langgraph_bot.utils.prompts import TITLE_BLOCK_PROMPT
 
 
+class TitleBlockMetadata(BaseModel):
+    content: str
+    tags: list[str]
+    difficulty: Literal["beginner", "intermediate", "advanced"]
+    estimated_time: str
+
+
+# LangChain Output Parser for validating and parsing LLM output 
+title_block_parser = PydanticOutputParser(pydantic_object=TitleBlockMetadata)
+
+
+#LEGACY TITLE NODE - NOT USED ANYMORE, keeping for reference until we are sure the new title block node is working well.
 def update_title_node(state: State):
     for msg in reversed(state["messages"]):
         if isinstance(msg, ToolMessage) and msg.name == "title_tool":
@@ -10,3 +29,45 @@ def update_title_node(state: State):
     return {}
 
 
+def _fallback_title_block(state: State) -> dict:
+    title = state.get("title") or state.get("topic") or "Untitled Post"
+    return {
+        "content": title,
+        "tags": [],
+        "difficulty": "beginner",
+        "estimated_time": "3 min read",
+    }
+
+
+def generate_title_block_node(state: State):
+    """
+    Generate frontend TitleBlock metadata while keeping the plain `title`
+    string in state for existing DB and slug behavior.
+    """
+    prompt = TITLE_BLOCK_PROMPT.format(
+        posttitle=state.get("title") or state.get("topic") or "",
+        postdata=state.get("data") or "",
+        format_instructions=title_block_parser.get_format_instructions(),
+    )
+
+    # print(f"Prompt for Title Block Node:\n{prompt}") # Debug
+    try:
+        response = groqmodel.invoke(prompt)
+        content = response.content if hasattr(response, "content") else str(response)
+        
+        # Attempt to parse the title block metadata, but if it fails, use a fallback
+        title_block = title_block_parser.parse(content).model_dump()
+    except Exception as exc:
+        print(f"Title block generation failed, using fallback: {exc}")
+        title_block = _fallback_title_block(state)
+
+    final_title = title_block["content"].strip() or state.get("topic") or "Untitled Post"
+
+    title_block["content"] = final_title
+    title_block["date"] = datetime.now(timezone.utc).date().isoformat()
+    title_block["author"] = "AI Dictionary Bot"
+
+    return {
+        "title": final_title,
+        "title_block": title_block,
+    }

--- a/langgraph_bot/utils/prompts.py
+++ b/langgraph_bot/utils/prompts.py
@@ -24,6 +24,25 @@ TITLE_PROMPT = """
         - Single line only
 """
 
+TITLE_BLOCK_PROMPT = """
+    You are generating metadata for a frontend TitleBlock.
+
+    Given:
+    - Existing title: {posttitle}
+    - Source content: {postdata}
+
+    Rules:
+    - content must be a professional 5-7 word title.
+    - tags must contain 2-5 short topic tags.
+    - difficulty must be exactly one of: beginner, intermediate, advanced.
+    - estimated_time must be a short reading time like "3 min read".
+    - Do not include date or author; the backend will add those.
+    - No markdown.
+    - No explanations.
+
+    {format_instructions}
+"""
+
 DESCRIPTION_PROMPT = """
         You are an  Expert description agent.you make large posts about new ai topics. you will be given some data for the context. 
         then you need to understand it and write content for the post. Your main work will be to descriptively explain the concept of the context data you are given.

--- a/langgraph_bot/workflow/workflow.py
+++ b/langgraph_bot/workflow/workflow.py
@@ -3,28 +3,24 @@ import pprint
 
 from langchain_core.messages import HumanMessage
 from langgraph.graph import END, START, StateGraph
-from langgraph.prebuilt import ToolNode
 
 from langgraph_bot.agentschema.stateschema import State
 from langgraph_bot.nodes.anode.agentnode import summary_agent_node
 from langgraph_bot.nodes.load_data_node import load_data
-from langgraph_bot.nodes.tnode.title_node import update_title_node
+from langgraph_bot.nodes.tnode.title_node import generate_title_block_node
 from langgraph_bot.nodes.tnode.slug_update_node import slug_node
-from langgraph_bot.tools.tools import title_tool
 
 graph_builder = StateGraph(state_schema=State)
 # graph_builder.add_node("load_data", load_data)
+graph_builder.add_node("generate_title_block", generate_title_block_node)
 graph_builder.add_node("summary_agent", summary_agent_node)
-graph_builder.add_node("title_tool_node", ToolNode([title_tool]))
-graph_builder.add_node("title_update", update_title_node)
 graph_builder.add_node("slug_node",slug_node)
 
 
-graph_builder.add_edge(START, "summary_agent")
-graph_builder.add_edge("summary_agent", "title_tool_node")
-graph_builder.add_edge("title_tool_node", "title_update")
-graph_builder.add_edge("title_update", "slug_node")
-graph_builder.add_edge("slug_node",END)
+graph_builder.add_edge(START, "generate_title_block")
+graph_builder.add_edge("generate_title_block", "slug_node")
+graph_builder.add_edge("slug_node", "summary_agent")
+graph_builder.add_edge("summary_agent",END)
 graph = graph_builder.compile()
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Changelog

**Date:** May 18, 2026

## Added

- **TitleBlock Generation System** (`langgraph_bot/nodes/tnode/title_node.py`)
  - Introduced `TitleBlockMetadata` Pydantic model with fields: `content`, `tags`, `difficulty`, and `estimated_time`
  - Implemented `generate_title_block_node()` function to generate structured title block metadata using LLM
  - Added `_fallback_title_block()` utility function for default metadata fallback behavior
  - Integrated `PydanticOutputParser` for reliable metadata parsing

- **Title Block Prompt** (`langgraph_bot/utils/prompts.py`)
  - Added `TITLE_BLOCK_PROMPT` constant with instructions for generating frontend-ready TitleBlock metadata

- **State Schema Enhancement** (`langgraph_bot/agentschema/stateschema.py`)
  - Added `title_block` field (Optional[dict]) to State TypedDict with replace_reducer

- **Data Integration** (`langgraph_bot/insert_bot_data.py`)
  - Extended `insert_cleaned_data()` to include "title" field in content_data payload sourced from title_block

- **Workflow Integration** (`langgraph_bot/main.py`)
  - Updated `run_entire_flow()` to include title_block field in clean_post structure

## Changed

- **Workflow Architecture** (`langgraph_bot/workflow/workflow.py`)
  - Removed legacy ToolNode-based title tooling
  - Replaced `update_title_node` with new `generate_title_block_node`
  - Updated execution path: `generate_title_block` → `slug_node` → `summary_agent` → `END`

- **Summary Agent** (`langgraph_bot/agents/summaryagent.py`)
  - Removed `title_tool` registration from summary agent configuration
  - Simplified tools list to empty configuration

- **Debug Logging** (`backend/db/client.py`)
  - Added debug print statements differentiating between local (127.0.0.1) and remote (supabase.co) Supabase instances

## Removed

- Legacy `title_tool` and `slug_tool` imports from title node module
- ToolNode-based title generation from workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recent-ai/Ai-Dictionary/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->