### PR TITLE
fix: Update imports and remove unused code across multiple files

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,3 +39,6 @@ select = [
     # flake8-bugbear
     "B"
 ]
+ignore = [
+    "E501"
+]

--- a/langgraph_bot/agents/coding_agent.py
+++ b/langgraph_bot/agents/coding_agent.py
@@ -1,13 +1,11 @@
 from dotenv import load_dotenv
 
-load_dotenv()
-import asyncio
-from langgraph_bot.agentschema.stateschema import State
 from langchain.agents import create_agent
+from langgraph_bot.agentschema.stateschema import State
 from langgraph_bot.models.generativemodel import groqmodel
-from pprint import pprint as pp
 from langgraph_bot.tools.tools import python_executor
 from langgraph_bot.utils.prompts import CODING_PROMPT
+load_dotenv()
 
 
 code_agent = create_agent(

--- a/langgraph_bot/agents/description_agent.py
+++ b/langgraph_bot/agents/description_agent.py
@@ -1,24 +1,13 @@
 from dotenv import load_dotenv
 
-load_dotenv()
-import asyncio
-from pprint import pprint as pp
-
 from langchain.agents import create_agent
-
 from langgraph_bot.agentschema.stateschema import State
 from langgraph_bot.models.generativemodel import groqmodel
-from langgraph_bot.tools.tools import (
-    arxiv_tool,
-    pdfreader_tool,
-    scraper_tool,
-    tavily_search_tool,
-)
 from langgraph_bot.utils.prompts import DESCRIPTION_PROMPT
+load_dotenv()
 
 agent = create_agent(
     model=groqmodel,
     state_schema=State,
     system_prompt=DESCRIPTION_PROMPT,
-    # tools=[arxiv_tool,tavily_search_tool,pdfreader_tool] #scraper_tool will be added soon for web scraping.
 )

--- a/langgraph_bot/agents/summaryagent.py
+++ b/langgraph_bot/agents/summaryagent.py
@@ -1,13 +1,10 @@
 from dotenv import load_dotenv
 
-load_dotenv()
-from pprint import pprint as pp
-
 from langchain.agents import create_agent
-
 from langgraph_bot.agentschema.stateschema import State
 from langgraph_bot.models.generativemodel import groqmodel
 from langgraph_bot.utils.prompts import SUMMARY_PROMPT
+load_dotenv()
 
 s_agent = create_agent(  # s refers to summary
     model=groqmodel,

--- a/langgraph_bot/models/generativemodel.py
+++ b/langgraph_bot/models/generativemodel.py
@@ -1,8 +1,6 @@
 from dotenv import load_dotenv
 from langchain.rate_limiters import InMemoryRateLimiter
-from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_groq import ChatGroq
-from langchain_openai import ChatOpenAI
 
 load_dotenv()
 

--- a/langgraph_bot/nodes/anode/agentnode.py
+++ b/langgraph_bot/nodes/anode/agentnode.py
@@ -1,4 +1,4 @@
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langgraph_bot.agents.description_agent import agent
 from langgraph_bot.agents.summaryagent import s_agent
 from langgraph_bot.agentschema.stateschema import State

--- a/langgraph_bot/nodes/tnode/description_tool_node.py
+++ b/langgraph_bot/nodes/tnode/description_tool_node.py
@@ -1,4 +1,3 @@
-from langchain_core.messages import ToolMessage
 from langgraph_bot.agentschema.stateschema import State
 from langgraph_bot.tools.tools import arxiv_tool, pdfreader_tool, tavily_search_tool
 

--- a/langgraph_bot/test_agent.py
+++ b/langgraph_bot/test_agent.py
@@ -1,6 +1,5 @@
 # from markdown import markdown
 # from bs4 import BeautifulSoup
-from agents.description_agent import agent
 from workflow.description_workflow import g
 
 

--- a/langgraph_bot/tools/tools.py
+++ b/langgraph_bot/tools/tools.py
@@ -1,11 +1,9 @@
 from dotenv import load_dotenv
-load_dotenv()
 import os
 import subprocess
 import tempfile
 from typing import Dict, List
 import requests
-# from langchain.messages import ToolMessage
 from langchain.tools import tool
 from langchain_community.document_loaders import (
     ArxivLoader,
@@ -13,9 +11,9 @@ from langchain_community.document_loaders import (
     UnstructuredPDFLoader,
 )
 from langchain_tavily import TavilySearch
-from langgraph.types import Command
 from langgraph_bot.models.generativemodel import groqmodel
 from langgraph_bot.utils.prompts import TITLE_PROMPT,SLUG_PROMPT
+load_dotenv()
 
 
 ## SUMMMARY AGENT TOOLS
@@ -122,7 +120,7 @@ def pdfreader_tool(pdf_list: List[Dict]) -> List:
             loader = UnstructuredPDFLoader(pdf_path)
             docs = loader.load()
             all_docs.extend(docs)
-        except (requests.RequestException, Exception) as e:
+        except (requests.RequestException, Exception):
             # Log error or handle gracefully - skip this PDF and continue
             pass
         finally:

--- a/langgraph_bot/workflow/description_workflow.py
+++ b/langgraph_bot/workflow/description_workflow.py
@@ -1,8 +1,4 @@
-import pprint
-
-from langchain_core.messages import HumanMessage
 from langgraph.graph import END, START, StateGraph
-from langgraph.prebuilt import ToolNode
 from pathlib import Path
 
 from langgraph_bot.agentschema.stateschema import State
@@ -10,13 +6,10 @@ from langgraph_bot.nodes.anode.agentnode import (
     description_agent_node,
     summary_agent_node,
 )
-from langgraph_bot.nodes.load_data_node import load_data
 from langgraph_bot.nodes.tnode.description_tool_node import (
-    arxiv_node,
     pdf_parsing_node,
     tavily_node,
 )
-from langgraph_bot.tools.tools import title_tool
 
 desc = StateGraph(state_schema=State)
 # desc.set_entry_point(START)

--- a/langgraph_bot/workflow/workflow.py
+++ b/langgraph_bot/workflow/workflow.py
@@ -1,12 +1,9 @@
 from pathlib import Path
-import pprint
 
-from langchain_core.messages import HumanMessage
 from langgraph.graph import END, START, StateGraph
 
 from langgraph_bot.agentschema.stateschema import State
 from langgraph_bot.nodes.anode.agentnode import summary_agent_node
-from langgraph_bot.nodes.load_data_node import load_data
 from langgraph_bot.nodes.tnode.title_node import generate_title_block_node
 from langgraph_bot.nodes.tnode.slug_update_node import slug_node
 


### PR DESCRIPTION
FIX IMPORTS and LINT ISSUES
No New feature introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Changelog

## [2026-05-19]

### Fixed
- **Import cleanup across multiple modules:**
  - Removed unused imports (`asyncio`, `pprint`, `BaseMessage`, `ToolMessage`, `HumanMessage`) from agents, nodes, and workflow modules
  - Removed unused tool imports from agents and workflow modules
  - Removed unused `load_data` imports from workflow modules
  - Removed unused `agent` import from test files

- **Import reorganization:**
  - Reordered imports in `langgraph_bot/agents/coding_agent.py`, `langgraph_bot/agents/description_agent.py`, and `langgraph_bot/tools/tools.py` for consistency
  - Moved `load_dotenv()` calls to occur after all module imports instead of immediately after the import statement

- **Updated dependencies in generativemodel:**
  - Added `ChatGroq` from `langchain_groq` 
  - Removed unused imports: `ChatGoogleGenerativeAI` from `langchain_google_genai` and `ChatOpenAI` from `langchain_openai`

- **Error handling improvements:**
  - Updated `pdfreader_tool` in `langgraph_bot/tools/tools.py` to remove unused exception variable binding

- **Linting configuration:**
  - Updated `backend/pyproject.toml` to ignore E501 (line-length) rule in Ruff linter configuration

### Changed
- Narrowed `description_workflow.py` imports to include only active workflow nodes (`pdf_parsing_node` and `tavily_node`)
- Removed `arxiv_node` import from workflow module

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recent-ai/Ai-Dictionary/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->